### PR TITLE
fix: validate max file size input and more bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automarkdown",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Intelligently convert codebases into markdown for LLMs to process and provide optimal insights",
   "main": "dist/index.js",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,9 +40,15 @@ program
       console.log(chalk.blue('Analyzing codebase...'));
 
       // Parse options
+      const maxFileSize = parseInt(options.maxSize);
+      if (isNaN(maxFileSize) || maxFileSize <= 0) {
+        console.error(chalk.red(`Error: Invalid max-size "${options.maxSize}". Must be a positive number.`));
+        process.exit(1);
+      }
+
       const conversionOptions = {
         includeHidden: options.includeHidden,
-        maxFileSize: parseInt(options.maxSize),
+        maxFileSize,
         excludePatterns: options.exclude.split(',').map((p: string) => p.trim()),
         includePatterns: options.include.split(',').map((p: string) => p.trim()),
         outputFormat: options.format as 'markdown' | 'json',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ const program = new Command();
 program
   .name('automarkdown')
   .description('Intelligently convert codebases into markdown for LLMs')
-  .version('2.0.0');
+  .version('2.0.1');
 
 program
   .argument('<path>', 'Path to the codebase to convert')


### PR DESCRIPTION
This pull request improves input validation and file exclusion logic in the codebase analysis tool. The main changes ensure that invalid `max-size` values are handled gracefully and that file and directory exclusions are more consistent and flexible, matching the patterns provided by the user.

**Input validation improvements:**

* Added validation for the `max-size` option in `src/cli.ts`, ensuring that it is a positive number and providing a clear error message if not.

**File exclusion and filtering enhancements:**

* Updated the `shouldIncludeInStructure` method in `src/parser.ts` to use user-specified exclusion patterns, supporting wildcards and file extensions, and aligning structure filtering with content filtering. Also improved handling of hidden files based on the `includeHidden` option.